### PR TITLE
only expose to localhost

### DIFF
--- a/assets/docker-compose.yml.j2
+++ b/assets/docker-compose.yml.j2
@@ -4,7 +4,7 @@ services:
   moodle:
     build: ./docker/moodle
     ports:
-      - "80:80"
+      - "127.0.0.1:80:80"
     volumes:
       - ./siteroot:/siteroot
 {% if db == 'psql' %}


### PR DESCRIPTION
We must bind to the lo interface to not have docker bind to all interfaces and thus expose too broadly.