### PR TITLE
Increase max_input_vars

### DIFF
--- a/assets/php-2004.ini
+++ b/assets/php-2004.ini
@@ -402,7 +402,7 @@ max_input_time = 60
 ;max_input_nesting_level = 64
 
 ; How many GET/POST/COOKIE input variables may be accepted
-;max_input_vars = 1000
+max_input_vars = 100000
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit


### PR DESCRIPTION
We need to increase max_input_vars for Moodle 3.11, 4.0 or later.

https://tracker.moodle.org/browse/MDL-71390